### PR TITLE
Fix password checker being in reverse

### DIFF
--- a/src/views/LoginView.tsx
+++ b/src/views/LoginView.tsx
@@ -162,7 +162,7 @@ const LoginForm: React.FC<LoginFormProps> = props => {
       return
     }
 
-    if (password === password2) {
+    if (password !== password2) {
       setError('password2', { type: 'validate', message: 'Passwords must be equal' })
     } else {
       clearErrors('password2')


### PR DESCRIPTION
If the password in both fields is `penis123`, then it will currently return an error.